### PR TITLE
chore: don't use saucelabs for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,16 @@ node_js: stable
 dist: trusty
 sudo: required
 addons:
-  sauce_connect: true
+  firefox: latest
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
 before_script:
   - npm install -g bower polylint web-component-tester
   - bower install
   - polylint
 script:
-  - wct -s 'default'
+  - xvfb-run wct
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s ''default''; fi'


### PR DESCRIPTION
Travis removes encrypted variables on PRs from forks for security reasons.