### PR TITLE
Minor graphical fix

### DIFF
--- a/salte-dialog-shared-styles.html
+++ b/salte-dialog-shared-styles.html
@@ -21,6 +21,7 @@ Custom property | Description | Default
         min-height: 531px;
         border-radius: 5px;
         overflow: hidden;
+        background: none;
 
         @apply --layout-vertical;
       }
@@ -37,6 +38,8 @@ Custom property | Description | Default
 
       :host ::content > *:not(h2):not(.buttons) {
         margin: 0;
+
+        background: var(--paper-dialog-background-color, --primary-background-color);
 
         @apply --layout-flex;
         @apply --layout-vertical;


### PR DESCRIPTION
On darker backgrounds, there were some white pixels you could see in the top corners.
Setting the host background to none fixes this, in order to keep the background that would have normally been there I added 
```CSS
background: var(--paper-dialog-background-color, --primary-background-color); 
```
to `:host ::content > *:not(h2):not(.buttons)`