### PR TITLE
BREAKING CHANGE: The dialog should resize to fit the content

### DIFF
--- a/salte-dialog-shared-styles.html
+++ b/salte-dialog-shared-styles.html
@@ -18,7 +18,6 @@ Custom property | Description | Default
     <style include="paper-dialog-shared-styles">
       :host {
         width: 360px;
-        min-height: 531px;
         border-radius: 5px;
         overflow: hidden;
         background: none;
@@ -37,11 +36,12 @@ Custom property | Description | Default
       }
 
       :host ::slotted(*:not(h2):not(.buttons)) {
+        display: block;
         margin: 0;
+        padding: 14px 24px;
 
         background: var(--paper-dialog-background-color, var(--primary-background-color));
 
-        @apply --layout-flex;
         @apply --layout-vertical;
         @apply --salte-dialog-content;
       }


### PR DESCRIPTION
- Currently we have a min-height set that gives
  the dialog a static height. This was accidentally
  pulled over from salte-feedback-dialog before it
  was stripped out to become salte-dialog

closes #10 